### PR TITLE
[macOS] Redo cyclecount for Apple silicon

### DIFF
--- a/src/benchmark.cc
+++ b/src/benchmark.cc
@@ -16,6 +16,7 @@
 
 #include "benchmark_api_internal.h"
 #include "benchmark_runner.h"
+#include "cycleclock.h"
 #include "internal_macros.h"
 
 #ifndef BENCHMARK_OS_WINDOWS
@@ -764,6 +765,7 @@ void Initialize(int* argc, char** argv, void (*HelperPrintf)()) {
   internal::HelperPrintf = HelperPrintf;
   internal::ParseCommandLineFlags(argc, argv);
   internal::LogLevel() = FLAGS_v;
+  internal::InitializeCyclecount();
 }
 
 void Shutdown() { delete internal::global_context; }

--- a/src/cycleclock.cc
+++ b/src/cycleclock.cc
@@ -1,0 +1,58 @@
+// Copyright 2016 Kris Kwiatkowski. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cycleclock.h"
+
+#include "internal_macros.h"
+
+#if defined(BENCHMARK_MACOS_AARCH64)
+#include "macOS_aarch64_cpmu.h"
+#endif
+
+namespace benchmark {
+namespace internal {
+void InitializeCyclecount() {
+#ifdef BENCHMARK_MACOS_AARCH64
+  (void)::benchmark::internal::init_macOS_rdtsc();
+#endif
+}
+}  // namespace internal
+
+namespace cycleclock {
+bool IsCycleClockEnabled() {
+#if BENCHMARK_MACOS_AARCH64
+  return ::benchmark::internal::macOS_rdtsc() != 0;
+#elif defined(__aarch64__) || (defined(__ARM_ARCH) && (__ARM_ARCH >= 6))
+// Check ARM PMU.
+// NOTE: only i386 and x86_64 have been well tested.
+// PPC, sparc, alpha, and ia64 are based on
+//    http://peter.kuscsik.com/wordpress/?p=14
+// with modifications by m3b.  See also
+//    https://setisvn.ssl.berkeley.edu/svn/lib/fftw-3.0.1/kernel/cycle.h
+#if defined(__aarch64__)
+  uint64_t pmuseren;
+  asm volatile("MRS %0, pmuserenr_el0" : "=r"(pmuseren));
+  return (1 == (pmuseren & 1));
+#else
+  uint32_t pmuseren;
+  asm volatile("mrc p15, 0, %0, c9, c14, 0" : "=r"(pmuseren));
+  return (1 == (pmuseren & 1));
+#endif
+#endif
+  // By default we return true and allow caller to perform further checks.
+  return true;
+}
+
+}  // namespace cycleclock
+}  // namespace benchmark

--- a/src/internal_macros.h
+++ b/src/internal_macros.h
@@ -66,6 +66,9 @@
     #if defined(TARGET_OS_IPHONE)
       #define BENCHMARK_OS_IOS 1
     #endif
+    #if defined(__aarch64__)
+      #define BENCHMARK_MACOS_AARCH64 1
+    #endif
   #endif
 #elif defined(__FreeBSD__)
   #define BENCHMARK_OS_FREEBSD 1
@@ -108,11 +111,6 @@
   #define BENCHMARK_MAYBE_UNUSED __attribute__((unused))
 #else
   #define BENCHMARK_MAYBE_UNUSED
-#endif
-
-#if defined(__APPLE__) && defined(__MACH__) && defined(__aarch64__)
-// macOS, aarch64
-  #define BENCHMARK_MACOS_AARCH64
 #endif
 
 // clang-format on

--- a/src/macOS_aarch64_cpmu.cc
+++ b/src/macOS_aarch64_cpmu.cc
@@ -68,7 +68,11 @@ KPERF_LIST
 static uint64_t g_counters[COUNTERS_COUNT];
 static uint64_t g_config[COUNTERS_COUNT];
 
-bool configure_macOS_rdtsc() {
+/*
+  Configure the counter. Such as clock cycles, etc.
+  Return false if it failed to configure, otherwise return true.
+ */
+static bool configure_macOS_rdtsc() {
   if (kpc_set_config(KPC_MASK, g_config)) {
     return false;
   }

--- a/src/macOS_aarch64_cpmu.h
+++ b/src/macOS_aarch64_cpmu.h
@@ -15,11 +15,8 @@
 
 #ifdef BENCHMARK_MACOS_AARCH64
 
-/*
-  Configure the counter. Such as clock cycles, etc.
-  Return false if it failed to configure, otherwise return true.
- */
-bool configure_macOS_rdtsc();
+namespace benchmark {
+namespace internal {
 
 /*
   Initialise and configure the rdtsc counter modules.
@@ -34,6 +31,8 @@ bool init_macOS_rdtsc();
  */
 unsigned long long int macOS_rdtsc();
 
+}  // namespace internal
+}  // namespace benchmark
 #endif  // BENCHMARK_MACOS_AARCH64
 
 #endif  // MACOS_AARCH64_CPMU_H_


### PR DESCRIPTION
* Complete redesign of CPU cyclecount for M1 chip. The previous one this functionality caused a system crash.
* The functionality is enabled automatically if available
* New API benchmark::cycleclock::IsCycleClockEnabled added in order to make it possible for the caller to determine if CPU cyclecount is enabled.